### PR TITLE
Use e.key instead of e.keyCode

### DIFF
--- a/snipplet.js
+++ b/snipplet.js
@@ -1,9 +1,9 @@
 var currentHighlighted = null;
 
 window.onkeyup = function (e) {
-  var key = e.keyCode ? e.keyCode : e.which;
+  var key = e.key;
 
-  if (key != 187 && key != 189) {
+  if (key != '-' && key != '=') {
     return;
   }
 
@@ -43,9 +43,9 @@ window.onkeyup = function (e) {
 
   var newIndex = currentIndex;
   if (!firstTime) {
-    if (key == 189) {
+    if (key == '-') {
       newIndex = Math.max(0, currentIndex - 1);
-    } else if (key == 187) {
+    } else if (key == '=') {
       newIndex = Math.min(responses.length - 1, currentIndex + 1);
     }
   }


### PR DESCRIPTION
... which adds Firefox support, because e.keyCode returns different numbers for <kbd>-</kbd> and <kbd>=</kbd> in Firefox. The [browser support](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key#Browser_compatibility) is still pretty good.